### PR TITLE
Added support for Turbolinks 5

### DIFF
--- a/app/assets/javascripts/plugins/camaleon_google_analytic/google_analytics.js.coffee
+++ b/app/assets/javascripts/plugins/camaleon_google_analytic/google_analytics.js.coffee
@@ -21,6 +21,7 @@ class @GoogleAnalytics
 
     if typeof Turbolinks isnt 'undefined' and Turbolinks.supported
       document.addEventListener "page:change", GoogleAnalytics.trackPageview, true
+      document.addEventListener "turbolinks:load", GoogleAnalytics.trackPageview, true
     else
       GoogleAnalytics.trackPageview()
 


### PR DESCRIPTION
Turbolinks 5 has new event names. This change adds an event listener for the new event, which functions similarly to the `page:change` event in previous versions.
